### PR TITLE
Add -deflate flag, store files instead of deflating by default

### DIFF
--- a/cmd/mangaconv/main.go
+++ b/cmd/mangaconv/main.go
@@ -20,6 +20,8 @@ func main() {
 	cutoff := flag.Float64("cutoff", 1, `Autocontrast cutoff.
 This value is the percentage of brightest and darkest pixels ignored when normalizing the histogram.
 Applying a cutoff nets a more perceivable contrast improvement.`)
+	deflate := flag.Bool("deflate", false, `Additionally compress the output cbz files.
+This is usually not worthwhile, as jpg files are already compressed`)
 	gamma := flag.Float64("gamma", 0.75, `Gamma correction value.
 Values < 1 darken the image, > 1 brighten it and 1 disables gamma correction.
 The default will look too dark on your computer screen, but much richer than before on e-ink.`)
@@ -57,10 +59,11 @@ If provided directory does not exist, mangaconv will attempt to create it. (defa
 	}()
 
 	converter := mangaconv.New(mangaconv.Params{
-		Cutoff: *cutoff,
-		Gamma:  *gamma,
-		Height: *height,
-		Width:  *width,
+		Cutoff:  *cutoff,
+		Deflate: *deflate,
+		Gamma:   *gamma,
+		Height:  *height,
+		Width:   *width,
 	})
 
 	var wg sync.WaitGroup

--- a/mangaconv.go
+++ b/mangaconv.go
@@ -19,14 +19,17 @@ import (
 // Params adjust how each page of a manga is transformed. For sane defaults, see cmd/mangaconv.
 //
 // Cutoff is the % of brightest and darkest pixels ignored when applying histogram normalization.
+// Deflate controls whether or not an image should be additionally compressed when saved to a cbz
+// file.
 // Gamma is the multiplier by which an image is darkened or brightened. Values > 1 brighten and
 // values < 1 darken it, with 1 leaving the image as is.
 // Height and Width describe a bounding box in which the output image will be fit.
 type Params struct {
-	Cutoff float64
-	Gamma  float64
-	Height int
-	Width  int
+	Cutoff  float64
+	Deflate bool
+	Gamma   float64
+	Height  int
+	Width   int
 }
 
 // New creates a new Converter with the provided Params.
@@ -78,7 +81,7 @@ func (c *Converter) ConvertToWriter(in string, out io.Writer) error {
 	})
 
 	errg.Go(func() error {
-		return c.writeZip(out, converted)
+		return c.writeZip(out, c.params.Deflate, converted)
 	})
 
 	return errg.Wait()

--- a/writer.go
+++ b/writer.go
@@ -11,11 +11,19 @@ import (
 	"io"
 )
 
-func (c *Converter) writeZip(writer io.Writer, pages <-chan page) error {
+func (c *Converter) writeZip(writer io.Writer, deflate bool, pages <-chan page) error {
+	method := zip.Store
+	if deflate {
+		method = zip.Deflate
+	}
+
 	w := zip.NewWriter(writer)
 	defer w.Close()
 	for p := range pages {
-		f, err := w.Create(fmt.Sprintf("%09d.jpg", p.Index))
+		f, err := w.CreateHeader(&zip.FileHeader{
+			Name:   fmt.Sprintf("%09d.jpg", p.Index),
+			Method: method,
+		})
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This PR changes the default method by which files are added to the resulting zip archive from `zip.Deflate` to `zip.Store`. It also adds a `-deflate` flag, which may be used if the small size benefit is desirable.

I'm not sure how did I not think of this earlier, but deflating jpg files nets very negligible results, while non-negligibly affecting performance (empirical evidence suggests <2mb @ ~100mb output size).

The performance benefits are illustrated below, new @ cff510b, old @ a543ea0
```
name                    old time/op    new time/op    delta
Converter/testdata-12     6.21ms ± 2%    4.09ms ± 1%  -34.08%  (p=0.008 n=5+5)
Converter/ddd-12           7.94s ± 1%     6.16s ± 1%  -22.44%  (p=0.008 n=5+5)
Converter/happiness-12     10.0s ± 1%      9.4s ± 1%   -6.53%  (p=0.008 n=5+5)

name                    old alloc/op   new alloc/op   delta
Converter/testdata-12     5.20MB ± 1%    4.61MB ± 1%  -11.22%  (p=0.008 n=5+5)
Converter/ddd-12          6.04GB ± 7%    6.03GB ± 9%     ~     (p=0.841 n=5+5)
Converter/happiness-12    23.7GB ± 1%    23.3GB ± 2%     ~     (p=0.095 n=5+5)

name                    old allocs/op  new allocs/op  delta
Converter/testdata-12      4.05k ± 0%     4.04k ± 0%   -0.23%  (p=0.008 n=5+5)
Converter/ddd-12           27.1k ± 0%     27.0k ± 0%     ~     (p=0.111 n=5+5)
Converter/happiness-12     6.62M ± 0%     6.62M ± 0%   -0.00%  (p=0.008 n=5+5)
```
`grayscale` and `ycbcr` are sample volumes from my manga collection, each around 200 pages and 300mb in size, scaled to a bounding box of 1920 x 1920. `grayscale` is correctly encoded as grayscale, while `ycbcr` needs to use stdlib `jpeg.Decoder`, hence the very high memory usage. This issue is extensively documented [in a previous PR addressing memory usage inefficiencies](https://github.com/naisuuuu/mangaconv/pull/14#issuecomment-822124441).